### PR TITLE
deps: relax dependency constraints and lower minimum Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,18 +11,18 @@ authors = [
 ]
 description = "Aircraft performance modelling, trajectory prediction and optimisation, and visualisation with EUROCONTROL's BADA."
 readme = "README.md"
-requires-python = ">=3.12.3"
+requires-python = ">=3.11.5"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)"
 ]
 dependencies = [
-  "scipy>=1.17.1",
-  "numpy>=2.4.3",
-  "pandas>=3.0.1",
+  "scipy>=1.11.0",
+  "numpy>=1.26.0",
+  "pandas>=2.0.0",
   "simplekml>=1.3.6",
   "XlsxWriter>=3.2.9",
-  "xarray >=2026.2.0"
+  "xarray>=2024.10.0"
 ]
 license = { text = "EUPL-1.2" }
 
@@ -30,17 +30,17 @@ license = { text = "EUPL-1.2" }
 # linter, formatter, to build the docs, ..
 [project.optional-dependencies]
 dev = [
-  "sphinx-rtd-theme==3.1.0",
-  "Sphinx==9.1.0",
-  "pre-commit==4.5.1",
-  "sphinx-gallery==0.20.0",
-  "matplotlib==3.10.8",
-  "folium==0.20.0",
-  "pytest==9.0.2",
-  "build==1.4.0",
-  "twine==6.2.0",
+  "sphinx-rtd-theme>=3.0.0",
+  "Sphinx>=7.0.0",
+  "pre-commit>=4.0.0",
+  "sphinx-gallery>=0.16.0",
+  "matplotlib>=3.8.0",
+  "folium>=0.15.0",
+  "pytest>=8.0.0",
+  "build>=1.0.0",
+  "twine>=5.0.0",
   "readthedocs-sphinx-search>=0.3.2",
-  "ruff==0.15.5",
+  "ruff>=0.4.0",
   ]
 
 [project.urls]
@@ -50,7 +50,7 @@ dev = [
 docstring-code-format = true
 
 [tool.ruff]
-target-version = 'py312'
+target-version = 'py311'
 line-length = 79
 exclude = [
   ".git",


### PR DESCRIPTION
## Summary

This PR relaxes the dependency version constraints in `pyproject.toml` to allow `pyBADA` to be properly resolved by modern package managers (e.g., [uv](https://github.com/astral-sh/uv)) when used as a dependency in other projects. It also lowers the minimum Python version from `3.12.3` to `3.11.5`.

## Context

The current strict dependency pins make it impossible to install `pyBADA` alongside projects that use slightly older (but still recent) versions of `scipy`, `xarray`, or `pandas`. As a workaround, consumers currently have to install it with `pip install --no-deps --ignore-requires-python`, which bypasses all dependency safety checks. Relaxing the constraints would allow for a proper, standard installation.

## Changes

- **`requires-python`**: `>=3.12.3` → `>=3.11.5` — the codebase uses `match/case` (Python 3.10+) but no 3.12-specific features
- **Runtime dependencies**: replaced strict minimum pins with more permissive lower bounds (e.g., `scipy>=1.11.0`, `xarray>=2024.10.0`)
- **Dev dependencies**: replaced exact pins with minimum version constraints for broader compatibility
- **`ruff.target-version`**: `py312` → `py311`

## Testing

We verified that the existing unit tests pass with both the original dependency versions and with older versions (`scipy==1.16.3`, `xarray==2024.10.0`, `pandas==2.3.3`). However, we don't have visibility beyond these tests — we'd appreciate it if you could run more comprehensive testing to confirm nothing is affected by these relaxed constraints.

Thank you for your help! 🙏